### PR TITLE
ignore sauna.reload "Cannot reload" errors

### DIFF
--- a/Products/PDBDebugMode/pdblogging.py
+++ b/Products/PDBDebugMode/pdblogging.py
@@ -26,6 +26,8 @@ ignore_matchers = (
         '^Step .* has an invalid import handler$').search,
     re.compile(
         '^Step .* has an invalid export handler$').search,
+    re.compile(
+        '^Cannot reload .*$').search,
     )
 
 def error(self, msg, *args, **kw):
@@ -50,5 +52,5 @@ def error(self, msg, *args, **kw):
             post_mortem(traceback)
         else:
             set_trace()
-        
+
     return result

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.2dev - Unreleased
+------------------
+* ignore sauna.reload "Cannot reload" errors
+  [sunew]
+
 1.3.1 - Unreleased
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.1'
+version = '1.3.2dev'
 
 setup(name='Products.PDBDebugMode',
       version=version,


### PR DESCRIPTION
Avoid post mortems on "Cannot reload" when using both sauna.reload and PDBDebugMode
