### PR TITLE
include dependencies in zcml

### DIFF
--- a/Products/PDBDebugMode/configure.zcml
+++ b/Products/PDBDebugMode/configure.zcml
@@ -5,6 +5,12 @@
    xmlns:monkey="http://namespaces.plone.org/monkey"
    zcml:condition="have zope-debug-mode">
 
+    <include package="collective.monkeypatcher" />
+    <include
+        package="Products.CMFCore"
+        file="permissions.zcml"
+        />
+
     <monkey:patch
        class="Products.PDBDebugMode.pdblogging.LoggerClass"
        original="error"

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Include dependencies in zcml to fix use in a pip-based install.
+  [pbauer]
 
 
 2.0 (2019-04-01)

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,54 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.1.dev0'
+version = "2.1.dev0"
 
-setup(name='Products.PDBDebugMode',
-      version=version,
-      description="Post-mortem debugging on Zope exceptions",
-      long_description=open("README.txt").read() + "\n" + open(
-          os.path.join("docs", "HISTORY.txt")).read(),
-      classifiers=[
-          "Environment :: Web Environment",
-          "Topic :: Software Development :: Libraries :: Python Modules",
-          "Framework :: Plone",
-          "Framework :: Plone :: 5.2",
-          "Framework :: Zope :: 4",
-          "Operating System :: OS Independent",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-      ],
-      keywords='',
-      author='Ross Patterson',
-      author_email='me@rpatterson.net',
-      url='https://github.com/collective/Products.PDBDebugMode',
-      license='GPL',
-      packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['Products'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-          'collective.monkeypatcher',
-          # -*- Extra requirements: -*-
-          'six',
-      ],
-      extras_require={
-          'ipdb': ['ipdb>=0.3'],
-          'zodb': ['zope.testrunner'],
-          'zodb-testing': ['zope.testing'],
-      },
-      entry_points={
-          # -*- Entry points: -*-
-          'z3c.autoinclude.plugin': 'target = plone',
-      },
-      )
+setup(
+    name="Products.PDBDebugMode",
+    version=version,
+    description="Post-mortem debugging on Zope exceptions",
+    long_description=open("README.txt").read()
+    + "\n"
+    + open(os.path.join("docs", "HISTORY.txt")).read(),
+    classifiers=[
+        "Environment :: Web Environment",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Framework :: Plone",
+        "Framework :: Plone :: 5.2",
+        "Framework :: Plone :: 6.0",
+        "Framework :: Zope :: 4",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    keywords="",
+    author="Ross Patterson",
+    author_email="me@rpatterson.net",
+    url="https://github.com/collective/Products.PDBDebugMode",
+    license="GPL",
+    packages=find_packages(exclude=["ez_setup"]),
+    namespace_packages=["Products"],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        "setuptools",
+        "collective.monkeypatcher",
+        # -*- Extra requirements: -*-
+        "six",
+    ],
+    extras_require={
+        "ipdb": ["ipdb>=0.3"],
+        "zodb": ["zope.testrunner"],
+        "zodb-testing": ["zope.testing"],
+    },
+    entry_points={
+        # -*- Entry points: -*-
+        "z3c.autoinclude.plugin": "target = plone",
+    },
+)


### PR DESCRIPTION
Fix use with a pip-based install. 
To use it it must run in debug-mode with `make fg`. Add this to your makefile:

```
.PHONY: fg
fg: ## Start a Plone instance in debug-mode on localhost:8080
	PYTHONWARNINGS=ignore ./bin/runwsgi -d instance/etc/zope.ini
```
